### PR TITLE
[codex] Add blog post card grid

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,100 @@
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.blog-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  border: 0.05rem solid var(--md-default-fg-color--lightest);
+  border-radius: 0.4rem;
+  background: var(--md-default-bg-color);
+  box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 8%);
+  transition: border-color 150ms, box-shadow 150ms, transform 150ms;
+}
+
+.blog-card:hover {
+  border-color: var(--md-accent-fg-color);
+  box-shadow: 0 0.4rem 0.8rem rgb(0 0 0 / 12%);
+  transform: translateY(-0.1rem);
+}
+
+.blog-card__body {
+  flex: 1;
+  padding: 1rem 1rem 0.75rem;
+}
+
+.blog-card__title {
+  margin: 0 0 0.6rem;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.blog-card__title a {
+  color: var(--md-default-fg-color);
+}
+
+.blog-card__title a:hover,
+.blog-card__title a:focus-visible,
+.blog-card__link:hover,
+.blog-card__link:focus-visible {
+  color: var(--md-accent-fg-color);
+}
+
+.blog-card__categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.blog-card__categories a {
+  padding: 0.1rem 0.45rem;
+  border-radius: 1rem;
+  background: var(--md-default-fg-color--lightest);
+  color: var(--md-default-fg-color--light);
+  font-size: 0.65rem;
+}
+
+.blog-card__categories a:hover,
+.blog-card__categories a:focus-visible {
+  background: var(--md-accent-fg-color--transparent);
+  color: var(--md-accent-fg-color);
+}
+
+.blog-card__summary {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.75rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+}
+
+.blog-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 1rem;
+  border-top: 0.05rem solid var(--md-default-fg-color--lightest);
+  font-size: 0.65rem;
+}
+
+.blog-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  color: var(--md-default-fg-color--lighter);
+}
+
+.blog-card__link {
+  flex: none;
+  font-weight: 700;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,13 @@
 site_name: programki.eu
 theme:
   name: material
+  custom_dir: overrides
   features:
     - content.code.copy
 plugins:
   - blog:
-      blog_dir: . 
+      blog_dir: .
+      pagination_per_page: 30
   - search
   - tags
 nav:
@@ -22,3 +24,5 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+extra_css:
+  - stylesheets/extra.css

--- a/overrides/blog.html
+++ b/overrides/blog.html
@@ -1,0 +1,66 @@
+{% extends "main.html" %}
+
+{% block container %}
+  <div class="md-content" data-md-component="content">
+    <div class="md-content__inner">
+      <header class="md-typeset">
+        {{ page.content }}
+      </header>
+
+      <section class="blog-grid" aria-label="Blog posts">
+        {% for post in posts %}
+          {% set summary = post.meta.description or post.content | striptags | replace(post.post.title, "") | trim %}
+          {% if not summary %}
+            {% set summary = "Open this post to see its contents." %}
+          {% endif %}
+          <article class="blog-card">
+            <div class="blog-card__body">
+              <h2 class="blog-card__title">
+                <a href="{{ post.url | url }}">{{ post.post.title }}</a>
+              </h2>
+
+              {% if post.categories %}
+                <nav class="blog-card__categories" aria-label="Post categories">
+                  {% for category in post.categories %}
+                    <a href="{{ category.url | url }}">{{ category.title }}</a>
+                  {% endfor %}
+                </nav>
+              {% endif %}
+
+              <p class="blog-card__summary">
+                {{ summary | truncate(220, true, "...") }}
+              </p>
+            </div>
+
+            <footer class="blog-card__footer">
+              <div class="blog-card__meta">
+                <time datetime="{{ post.config.date.created }}">
+                  {{ post.config.date.created | date }}
+                </time>
+                {% if post.config.readtime %}
+                  <span aria-hidden="true">&middot;</span>
+                  <span>
+                    {% if post.config.readtime == 1 %}
+                      {{ lang.t("readtime.one") }}
+                    {% else %}
+                      {{ lang.t("readtime.other") | replace("#", post.config.readtime) }}
+                    {% endif %}
+                  </span>
+                {% endif %}
+              </div>
+              <a class="blog-card__link" href="{{ post.url | url }}">
+                Read post <span aria-hidden="true">&rarr;</span>
+              </a>
+            </footer>
+          </article>
+        {% endfor %}
+      </section>
+
+      {% if pagination %}
+        {% block pagination %}
+          {% include "partials/pagination.html" %}
+        {% endblock %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What changed

- Replace full post excerpts with a responsive card grid.
- Show post title, categories, summary, date, and read time.
- Keep all current posts on one homepage through a 30-post page size.
- Add Material theme override and responsive card styling.

## Why

Post discovery was driven mainly by archive dates. Cards make titles and categories scannable without opening date archives.

## Validation

- `mkdocs build --strict`
- Verified 27 cards render with no blank summaries.
- Verified archive and category links resolve correctly.