### PR TITLE
Add giscus comments to all blog posts

### DIFF
--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,18 @@
+{% if "posts/" in page.file.src_uri and page.meta.comments != false %}
+  <h2 id="__comments">Comments</h2>
+  <script src="https://giscus.app/client.js"
+          data-repo="inwenis/blog"
+          data-repo-id="MDEwOlJlcG9zaXRvcnkzNzYyNzc5OTg="
+          data-category="Announcements"
+          data-category-id="DIC_kwDOFm2L7s4DAkhF"
+          data-mapping="pathname"
+          data-strict="0"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-input-position="bottom"
+          data-theme="light"
+          data-lang="en"
+          crossorigin="anonymous"
+          async>
+  </script>
+{% endif %}


### PR DESCRIPTION
## What

Enables reader comments on every blog post via [giscus](https://giscus.app), backed by GitHub Discussions of this repo (Announcements category).

## How

- New `overrides/partials/comments.html` — mkdocs-material auto-includes this partial on content pages
- Widget renders only for pages under `posts/`
- Per-post opt-out: `comments: false` in front matter

## Prerequisites (already done)

- Discussions enabled on repo
- giscus app installed

## Verified

- Local build: widget in all 29 post pages, index/archive/tag pages clean
- `comments: false` opt-out tested
- Widget rendered in browser (localhost + brief live deploy, since reverted): sign-in button, reactions, no error box

## After merge

Run `deploy.ps1` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)